### PR TITLE
fix: do not make TS think the package has named exports in node16 with esm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,14 @@ import globals = require('./globals.js');
 import properties = require('./properties.js');
 import syntax = require('./syntax.js');
 
-const exprt: {
+interface ExportsType {
   createGlobals: globals.CreateFn;
   createProperties: properties.CreateFn;
   createSyntax: syntax.CreateFn;
-} = {
+}
+
+export = {
   createGlobals: globals,
   createProperties: properties,
   createSyntax: syntax,
-};
-export = exprt;
+} satisfies ExportsType as ExportsType;


### PR DESCRIPTION
Fixes https://github.com/bradzacher/eslint-no-restricted/issues/11

Currently, TypeScript produces the following `.d.ts` that makes it think the file has named exports in node16 mode with ESM ([see `attw` report here](https://arethetypeswrong.github.io/?p=eslint-no-restricted%400.0.8)):

```ts
declare const exprt: {
    createGlobals: globals.CreateFn;
    createProperties: properties.CreateFn;
    createSyntax: syntax.CreateFn;
};
export = exprt;
```

However, if the type is directly specified on an exported variable:

```ts
interface ExportsType {
  createGlobals: globals.CreateFn;
  createProperties: properties.CreateFn;
  createSyntax: syntax.CreateFn;
}

export = {
  createGlobals: globals,
  createProperties: properties,
  createSyntax: syntax,
} satisfies ExportsType as ExportsType;
```

The generated `.d.ts` will look like this and will be interpreted correctly:

```ts
import globals = require('./globals.js');
import properties = require('./properties.js');
import syntax = require('./syntax.js');
interface ExportsType {
    createGlobals: globals.CreateFn;
    createProperties: properties.CreateFn;
    createSyntax: syntax.CreateFn;
}
declare const _default: ExportsType;
export = _default;
```

That's exactly what's been done in this PR.